### PR TITLE
Add Postgres integration test

### DIFF
--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -6,3 +6,7 @@ edition = "2024"
 [dependencies]
 sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-native-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[dev-dependencies]
+testcontainers = "0.24"
+testcontainers-modules = { version = "0.12", features = ["postgres"] }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -24,7 +24,7 @@ pub struct Table {
     pub columns: Vec<Column>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Value {
     Int(i64),
     Text(String),

--- a/db/tests/postgres.rs
+++ b/db/tests/postgres.rs
@@ -1,0 +1,51 @@
+use db::{Column, DataType, Table, Value};
+use sqlx::postgres::PgPoolOptions;
+use std::collections::HashMap;
+use testcontainers::runners::AsyncRunner;
+use testcontainers_modules::postgres::Postgres;
+
+#[tokio::test]
+async fn insert_and_select() -> Result<(), Box<dyn std::error::Error>> {
+    let node = Postgres::default().start().await?;
+
+    let connection_string = format!(
+        "postgres://postgres:postgres@{}:{}/postgres",
+        node.get_host().await?,
+        node.get_host_port_ipv4(5432).await?
+    );
+
+    let pool = PgPoolOptions::new()
+        .max_connections(1)
+        .connect(&connection_string)
+        .await?;
+
+    sqlx::query("CREATE TABLE items (id BIGINT PRIMARY KEY, name TEXT)")
+        .execute(&pool)
+        .await?;
+
+    let table = Table::new(
+        "items",
+        vec![
+            Column {
+                name: "id".into(),
+                data_type: DataType::Int,
+            },
+            Column {
+                name: "name".into(),
+                data_type: DataType::Text,
+            },
+        ],
+    );
+
+    let mut values = HashMap::new();
+    values.insert("id".into(), Value::Int(1));
+    values.insert("name".into(), Value::Text("hello".into()));
+
+    table.insert(&pool, values).await?;
+
+    let rows = table.select(&pool, None).await?;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("name"), Some(&Value::Text("hello".into())));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add testcontainers dependencies
- implement Value equality
- create Postgres integration test using testcontainers

## Testing
- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test --workspace` *(fails: Client(Init(SocketNotFoundError("/var/run/docker.sock")))*

------
https://chatgpt.com/codex/tasks/task_e_6863b00b4908832888a8e828f5ac4f3c